### PR TITLE
Fix setuptools directive for Python package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-from setuptools import setup
+from setuptools import setup, find_packages
 
 
 setup(name="clrriskmodels",
@@ -8,4 +8,5 @@ setup(name="clrriskmodels",
       author_email="dev@color.com",
       url="https://github.com/ColorGenomics/risk-models",
       license="Apache-2.0",
+      packages=find_packages(),
 )

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 
 setup(name="clrriskmodels",
-      version="1.1.0",
+      version="1.1.1",
       description="Color Genomics Risk Models",
       author="Color Genomics",
       author_email="dev@color.com",


### PR DESCRIPTION
Building `clrriskmodels` was producing a broken Python package and only worked when used in an "editable" install. Fixed by turning on setuptools package autodiscovery via `packages=find_packages()`.